### PR TITLE
ci: clean-deploy on tag, skip redundant verify (fixes signature failure)

### DIFF
--- a/.github/workflows/ci-publish.yml
+++ b/.github/workflows/ci-publish.yml
@@ -44,11 +44,12 @@ jobs:
           mvn versions:set -DnewVersion=$VERSION -DgenerateBackupPoms=false
 
       - name: Build and test
+        if: "!startsWith(github.ref, 'refs/tags/v')"
         run: mvn verify
 
       - name: Publish to Maven Central
         if: startsWith(github.ref, 'refs/tags/v')
-        run: mvn deploy -Prelease -DskipTests
+        run: mvn -Prelease clean deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}


### PR DESCRIPTION
## Summary

The release workflow's two-step `mvn verify` then `mvn deploy -Prelease -DskipTests` leaves unsigned package outputs in `target/` from step 1, then re-enters the lifecycle in step 2 without a `clean`. Some artifact bytes end up out of sync with the `.asc` files that `gpg:sign` produces, and Sonatype rejects the deployment.

## Symptom on v1.3.0-beta1

Tag push run [#25204059838](https://github.com/4ment/flc/actions/runs/25204059838) failed with:

```
Deployment d85e2a2e-42c1-4187-98e8-51dd2bbafeb8 failed
pkg:maven/io.github.4ment/flc@1.3.0-beta1:
 - Invalid signature for file: flc-1.3.0-beta1.zip.asc
 - Invalid signature for file: flc-1.3.0-beta1-javadoc.jar.asc
 - Invalid signature for file: flc-1.3.0-beta1-sources.jar.asc
```

The main `flc-1.3.0-beta1.jar.asc` and `.pom.asc` verified fine; only the assembly zip, sources jar, and javadoc jar failed.

## Fix

- Gate ``Build and test`` to non-tag pushes (the deploy step now runs the full lifecycle including tests).
- Replace `mvn deploy -Prelease -DskipTests` with `mvn -Prelease clean deploy` so the release runs from a clean `target/` in a single mvn invocation.

## Verified

Applied the same change to [`CompEvol/morph-models`](https://github.com/CompEvol/morph-models) and successfully published [`v1.3.0-beta3`](https://repo1.maven.org/maven2/io/github/compevol/morph-models/1.3.0-beta3/) to Maven Central — same workflow template, same plugin set (`central-publishing-maven-plugin` 0.6.0, `maven-gpg-plugin` 3.2.7).

## Re-releasing v1.3.0-beta1

The Sonatype staging deployment was rejected so the version isn't consumed on Central. To re-release after this PR merges, either delete and re-push the existing `v1.3.0-beta1` tag, or cut a `v1.3.0-beta2`.

## Test plan

- [x] morph-models tag CI succeeded with the same fix
- [x] Both `morph-models-1.3.0-beta3.pom` and `.zip` are HTTP 200 on Maven Central
- [ ] On merge, retag and confirm the FLC tag CI passes