### PR TITLE
FQN MRCAPrior to its beast.base.spec.* equivalent

### DIFF
--- a/examples/Human.H3.81-98-elc-StrictClock.xml
+++ b/examples/Human.H3.81-98-elc-StrictClock.xml
@@ -297,7 +297,7 @@
 
             </distribution>
 
-            <distribution id="new.prior" monophyletic="true" spec="beast.base.evolution.tree.MRCAPrior"
+            <distribution id="new.prior" monophyletic="true" spec="beast.base.spec.evolution.tree.MRCAPrior"
                           tree="@Tree.t:fluA">
                 <taxonset id="taxonset.new" spec="TaxonSet">
                     <taxon id="A_Akita_1_1994" spec="Taxon"/>

--- a/examples/Human.H3.81-98-elc.xml
+++ b/examples/Human.H3.81-98-elc.xml
@@ -312,7 +312,7 @@
  -->
             </distribution>
 
-            <distribution id="new.prior" monophyletic="true" spec="beast.base.evolution.tree.MRCAPrior"
+            <distribution id="new.prior" monophyletic="true" spec="beast.base.spec.evolution.tree.MRCAPrior"
                           tree="@Tree.t:fluA">
                 <taxonset id="taxonset.new" spec="TaxonSet">
                     <taxon id="A_Akita_1_1994" spec="Taxon"/>


### PR DESCRIPTION
## Summary

Two example XMLs reference `beast.base.evolution.tree.MRCAPrior` directly via `spec=`. That class is `@Deprecated` in beast3; the replacement lives at `beast.base.spec.evolution.tree.MRCAPrior`. After this change flc has no remaining references to deprecated classes in any of its XMLs or fxtemplates.

The substitution was surfaced by the new deprecated-class-reference pass in [CompEvol/beast3-migration](https://github.com/CompEvol/beast3-migration), which now cross-references every `spec=` and `<map>` value in tracked XMLs against the global `@Deprecated` FQN registry and suggests spec replacements where the same simple name exists under `.spec.`.

## Test plan

- [x] `mvn -q compile && mvn -q exec:exec -Dbeast.args="-overwrite examples/Human.H3.81-98-elc-StrictClock.xml"` runs end-to-end (verified locally with a temporary 50k chainLength, restored to 10M before commit). The other example uses the same FQN substitution.
- [ ] CI on this branch.